### PR TITLE
Fix AWS data access variables

### DIFF
--- a/distributed/api/celery_app/pslmodels_taxbrain_tasks.py
+++ b/distributed/api/celery_app/pslmodels_taxbrain_tasks.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 from api.celery_app import celery_app, task_wrapper
 
 
-AWS_ACCESS_KEY_ID = os.environ.pop("AWS_ACCESS_KEY_ID", "")
-AWS_SECRET_ACCESS_KEY = os.environ.pop("AWS_SECRET_ACCESS_KEY", "")
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
 
 
 @celery_app.task(

--- a/distributed/docker-compose.yml
+++ b/distributed/docker-compose.yml
@@ -35,9 +35,6 @@ services:
     depends_on:
       - redis
       - celerybase
-    environment:
-      - OBJ_STORAGE_ACCESS=${OBJ_STORAGE_ACCESS}
-      - OBJ_STORAGE_SECRET=${OBJ_STORAGE_SECRET}
     env_file:
       - ./dockerfiles/dev.env
     networks:
@@ -61,9 +58,6 @@ services:
       context: ./
       dockerfile: dockerfiles/projects/Dockerfile.pslmodels_taxbrain_tasks
     image: "comporg/pslmodels_taxbrain_tasks:${TAG}"
-    environment:
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
     env_file:
       - ./dockerfiles/dev.env
     depends_on:


### PR DESCRIPTION
This PR changes the way variables are passed to the dockers at run time. Now, they will be passed through environment files which should be removed after the containers are built. They are accessed in Python by the `get` method on `os.environ` instead of `pop`.