### PR TITLE
Handle unknown params

### DIFF
--- a/templates/comp/inputs_form.html
+++ b/templates/comp/inputs_form.html
@@ -4,6 +4,8 @@
 
 {% load strings %}
 {% load inputs %}
+{% load utility %}
+
 {% block content %}
 
 <form class="inputs-form model-param" id="inputs-form" method="post" action="{{app_url}}">
@@ -130,6 +132,41 @@
                   {{ error }}
                 </div>
             {% endfor %}
+            </div>
+            {% endif %}
+            {% if unknown_fields %}
+            <div class="card card-body card-outer">
+              <div class="alert alert-danger text-center lert-dismissible" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+                <p><b>The following parameter(s) may have been renamed or removed from {{project_name}}:</b></p>
+                {{ unknown_fields }}
+              </div>
+            </div>
+            {% endif %}
+            {% if model_parameters %}
+            <div class="card card-body card-outer">
+              <h1 style="font-size:2rem;">
+                Model Parameters as JSON
+                <div class="float-right">
+                  <button
+                    class="btn collapse-button"
+                    type="button"
+                    data-toggle="collapse"
+                    data-target="#modelparamsjson-collapse-major"
+                    aria-expanded="false"
+                    aria-controls="modelparamsjson-collapse-major"
+                    style="margin-left:20px;">
+                    <i class="far fa-plus-square" style="size:5x;" ></i>
+                  </button>
+                </div>
+              </h1>
+              <div class="collapse collapse-plus-minus" id="modelparamsjson-collapse-major">
+                <ul class="list-unstyled">
+                  <li><pre><code class="block">{{model_parameters|pprint_json}}</code></pre></li>
+                <ul>
+              </div>
             </div>
             {% endif %}
             {% for section, params in default_form.items %}

--- a/templates/comp/outputs/v1/sim_detail.html
+++ b/templates/comp/outputs/v1/sim_detail.html
@@ -52,7 +52,7 @@
                       <li><p><i> Meta Parameters:</i></p></li>
                       <li><pre><code class="block">{{object.inputs.meta_parameters|pprint_json}}</code></pre></li>
                       <li><p><i> Model Parameters: </i></p></li>
-                      <li><pre><code class="block">{{object.inputs.display_params|pprint_json}}</code></li></pre>
+                      <li><pre><code class="block">{{object.inputs.display_params|pprint_json}}</code></pre></li>
                       <ul>
                   </div>
                 </div>

--- a/webapp/apps/comp/displayer.py
+++ b/webapp/apps/comp/displayer.py
@@ -11,9 +11,9 @@ class Displayer:
         self.meta_parameters = meta_parameters
         self._cache = {}
 
-    def defaults(self, flat=True):
+    def defaults(self, flat=True, use_param_cls=True):
         if flat:
-            return self._default_flatdict()
+            return self._default_flatdict(use_param_cls=use_param_cls)
         else:
             return self._default_form()
 
@@ -45,7 +45,7 @@ class Displayer:
             }
         return result
 
-    def _default_flatdict(self):
+    def _default_flatdict(self, use_param_cls=True):
         """
         Get _flat_ dictionary of default parameters, i.e. major section types
         are collapsed. This is used to specify the default inputs on the Django
@@ -56,8 +56,11 @@ class Displayer:
         default_params = {}
         for defaults in raw_defaults.values():
             for k, v in defaults.items():
-                param = self.Param(k, v, **self.meta_parameters)
-                default_params[param.name] = param
+                if use_param_cls:
+                    param = self.Param(k, v, **self.meta_parameters)
+                    default_params[param.name] = param
+                else:
+                    default_params[k] = v
         return default_params
 
     def _default_form(self):

--- a/webapp/apps/comp/exceptions.py
+++ b/webapp/apps/comp/exceptions.py
@@ -10,3 +10,7 @@ class AppError(COMPError):
         self.parameters = json.dumps(parameters, indent=4)
         self.traceback = traceback
         super().__init__(traceback)
+
+
+class MatchFailedError(COMPError):
+    pass

--- a/webapp/apps/comp/forms.py
+++ b/webapp/apps/comp/forms.py
@@ -14,7 +14,8 @@ class InputsForm(forms.Form):
             clean_meta_parameters = self.meta_parameters.validate(fields)
         elif kwargs.get("initial", None) is not None:
             # GET edit inputs form
-            clean_meta_parameters = self.meta_parameters.validate(kwargs.get("initial"))
+            clean_meta_parameters = self.meta_parameters.validate(kwargs["initial"])
+            kwargs["initial"].update(clean_meta_parameters)
         else:
             # GET fresh inputs form
             clean_meta_parameters = self.meta_parameters.validate({})

--- a/webapp/apps/comp/tests/test_submit.py
+++ b/webapp/apps/comp/tests/test_submit.py
@@ -23,7 +23,7 @@ def test_submit(db, get_inputs, meta_param_dict, profile):
     class MockParser(BaseParser):
         def parse_parameters(self):
             errors_warnings, params = super().parse_parameters()
-            return errors_warnings, params
+            return errors_warnings, params, None
 
     project = Project.objects.get(title="Used-for-testing")
     ioutils = get_ioutils(
@@ -59,7 +59,7 @@ def test_submit_sponsored(db, get_inputs, meta_param_dict, profile):
     class MockParser(BaseParser):
         def parse_parameters(self):
             errors_warnings, params = super().parse_parameters()
-            return errors_warnings, params
+            return errors_warnings, params, None
 
     project = Project.objects.get(title="Used-for-testing-sponsored-apps")
     ioutils = get_ioutils(
@@ -99,7 +99,7 @@ def test_submit_w_errors(db, get_inputs, meta_param_dict, profile):
     class MockParser(BaseParser):
         def parse_parameters(self):
             _, params = super().parse_parameters()
-            return mock_errors_warnings, params
+            return mock_errors_warnings, params, None
 
     project = Project.objects.get(title="Used-for-testing")
     ioutils = get_ioutils(

--- a/webapp/apps/comp/tests/test_utils.py
+++ b/webapp/apps/comp/tests/test_utils.py
@@ -3,7 +3,13 @@ import json
 import pytest
 import paramtools
 
-from webapp.apps.comp.utils import is_reverse, is_wildcard, json_int_key_encode
+from webapp.apps.comp.utils import (
+    is_reverse,
+    is_wildcard,
+    json_int_key_encode,
+    match_unknown_field,
+)
+from webapp.apps.comp.exceptions import MatchFailedError
 
 
 @pytest.mark.parametrize(
@@ -27,33 +33,19 @@ def test_json_int_key_encode():
     assert exp == act
 
 
-# def test_param_naming(TestParams: Parameters, pt_metaparam: dict):
-#     class TestParams(paramtools.Parameters):
-#         defaults = {
+def test_unknown_field():
+    form_fields = ["hello", "world", "hello_checkbox"]
+    flat_defaults = {"hello": {"title": "Hello"}, "world": {"title": "World"}}
 
-#         }
+    anchor_id, title = match_unknown_field("_ello", flat_defaults, form_fields)
 
-#     raw_meta_params = {"dim0": "zero"}
-#     mp_inst = pt_metaparam.validate(raw_meta_params)
-#     params = TestParams()
-#     spec = params.specification(meta_data=True, **mp_inst)
+    assert anchor_id == "#id_hello"
+    assert title == "Hello"
 
-#     pname = "min_int_param"
-#     fake_vi = {"dim0": "one", "dim1": "heyo", "dim2": "byo", "value": 123}
-#     param = Param(pname, spec[pname], **mp_inst)
-#     newname, suffix = dims_to_string(pname, fake_vi, mp_inst)
-#     assert suffix == "dim0__mp___dim1__heyo___dim2__byo"
-#     assert newname == pname + "____" + suffix
+    anchor_id, title = match_unknown_field("_ello_checkbox", flat_defaults, form_fields)
 
-#     param.set_fields([fake_vi])
-#     exp = "min_int_param____dim0__mp___dim1__heyo___dim2__byo"
-#     assert param.col_fields[-1].name == exp
-#     assert param.col_fields[-1].default_value == 123
-#     assert exp in param.fields
+    assert anchor_id == "#label-id_hello_checkbox"
+    assert title == "Hello"
 
-#     pname = "min_int_param"
-#     fake_vi = {"value": 123}
-#     param = Param(pname, spec[pname], **mp_inst)
-#     newname, suffix = dims_to_string(pname, fake_vi, mp_inst)
-#     assert suffix == ""
-#     assert newname == pname
+    with pytest.raises(MatchFailedError):
+        match_unknown_field("notclose", flat_defaults, form_fields)

--- a/webapp/apps/comp/utils.py
+++ b/webapp/apps/comp/utils.py
@@ -1,3 +1,9 @@
+import difflib
+from typing import Tuple
+
+from .exceptions import MatchFailedError
+
+
 def is_wildcard(x):
     if isinstance(x, str):
         return x in ("*", "*") or x.strip() in ("*", "*")
@@ -98,3 +104,28 @@ def dims_to_string(param_name, value_object, meta_parameters):
         return param_name + "____" + suffix, suffix
     else:
         return param_name, suffix
+
+
+def match_unknown_field(
+    field: str, flat_defaults: dict, form_fields: dict
+) -> Tuple[str, str]:
+    """
+    Try to match an unknown field to an existing field. This is helpful when 
+    variables have been renamed. This may also be helpful for finding a similar
+    parameter after a parameter has been removed.
+    """
+    # cpi is no longer used.
+    field = field.replace("cpi", "checkbox")
+    matches = difflib.get_close_matches(field, form_fields, n=1, cutoff=0.60)
+    if matches:
+        firstmatch = matches[0]
+        if firstmatch.endswith("_checkbox"):
+            firstmatch = firstmatch.replace("_checkbox", "")
+            cid = firstmatch.split("____")[0] + "_checkbox"
+            anchor_id = f"#label-id_{cid}"
+        else:
+            anchor_id = f"#id_{firstmatch}"
+        param_name = firstmatch.split("____")[0]
+        title = flat_defaults[param_name]["title"]
+        return anchor_id, title
+    raise MatchFailedError(f"Failed to find a match for {field}")

--- a/webapp/apps/comp/views.py
+++ b/webapp/apps/comp/views.py
@@ -19,6 +19,8 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.urls import reverse
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
+from django.utils.safestring import mark_safe
+
 
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -33,6 +35,7 @@ from webapp.apps.billing.utils import USE_STRIPE, ChargeRunMixin, has_payment_me
 from webapp.apps.users.models import Project, is_profile_active
 
 from .constants import WEBAPP_VERSION
+from .exceptions import MatchFailedError
 from .forms import InputsForm
 from .models import Simulation
 from .compute import Compute, JobFailError
@@ -41,6 +44,7 @@ from .submit import handle_submission, BadPost
 from .tags import TAGS
 from .exceptions import AppError
 from .serializers import OutputsSerializer
+from .utils import match_unknown_field
 
 
 OBJ_STORAGE_URL = os.environ.get("OBJ_STORAGE_URL")
@@ -274,13 +278,36 @@ class EditInputsView(GetOutputsObjectMixin, InputsMixin, View):
         inputs_form = InputsForm(project, ioutils.displayer, initial=initial)
         # clean data with is_valid call.
         inputs_form.is_valid()
-
+        unknown_fields = ""
+        flat_defaults = None
         for field, val in inputs_form.initial.items():
-            inputs_form.fields[field].initial = val
+            if val not in (None, ""):
+                try:
+                    inputs_form.fields[field].initial = val
+                except KeyError:
+                    if flat_defaults is None:
+                        flat_defaults = ioutils.displayer.defaults(use_param_cls=False)
+                    msg = f"{field} (user value=<b>{val}</b>) is unknown."
+                    if field.endswith("checkbox") or field.endswith("cpi"):
+                        msg += " This parameter is associated with another parameter as a blue box."
+                    try:
+                        anchor_id, title = match_unknown_field(
+                            field, flat_defaults, inputs_form.fields
+                        )
+                        msg += (
+                            f" A similar parameter: <a href='{anchor_id}'>{title}</a>"
+                        )
+                    except MatchFailedError:
+                        pass
+                    unknown_fields += f" <p>{msg}</p> "
+
+        unknown_fields = mark_safe(unknown_fields)
         # is_bound is turned off so that the `initial` data is displayed.
         # Note that form is validated and cleaned with is_bound call.
         inputs_form.is_bound = False
         context = self.project_context(request, project)
+        context.update({"unknown_fields": unknown_fields})
+        context.update({"model_parameters": self.object.inputs.display_params})
         return self._render_inputs_form(request, project, ioutils, inputs_form, context)
 
     def _render_inputs_form(self, request, project, ioutils, inputs_form, context):


### PR DESCRIPTION
This PR adds functionality for handling unknown parameters. This was developed to help the Tax-Brain app swap to the v1 inputs. I considered writing a converter to upgrade the existing v0 inputs to the new version. However, it was going to be tricky to handle all of the edge cases. Further, this functionality will be helpful in the future for when models change the name of a parameter or remove a parameter.

[`difflib.get_close_matches`][1] is used to find valid parameters that are similar to the unknown parameters. If there is a match, the user is given a link to the valid parameter:

![Screenshot from 2019-05-13 18-03-01](https://user-images.githubusercontent.com/9206065/57657447-5eaf9980-75a9-11e9-969d-51edecab9ef8.png)


[1]: https://docs.python.org/3.7/library/difflib.html#difflib.get_close_matches