### PR TITLE
Fix default reference time for ETA calculations

### DIFF
--- a/webapp/apps/comp/models.py
+++ b/webapp/apps/comp/models.py
@@ -161,7 +161,9 @@ class Simulation(models.Model):
     def json_filename(self):
         return f"{self.project.title}_{self.model_pk}.json"
 
-    def compute_eta(self, reference_time=timezone.now()):
+    def compute_eta(self, reference_time=None):
+        if reference_time is None:
+            reference_time = timezone.now()
         exp_comp_dt = self.exp_comp_datetime
         dt = exp_comp_dt - reference_time
         exp_num_minutes = dt.total_seconds() / 60.0

--- a/webapp/apps/comp/submit.py
+++ b/webapp/apps/comp/submit.py
@@ -143,6 +143,8 @@ class Submit:
         self.submitted_id, self.max_q_length = self.compute.submit_job(
             data, self.project.worker_ext(action=actions.SIM)
         )
+        print(f"job id: {self.submitted_id}")
+        print(f"q lenghth: {self.max_q_length}")
 
 
 class APISubmit(Submit):

--- a/webapp/apps/comp/views/views.py
+++ b/webapp/apps/comp/views/views.py
@@ -260,8 +260,8 @@ class EditInputsView(GetOutputsObjectMixin, InputsMixin, View):
                 try:
                     inputs_form.fields[field].initial = val
                 except KeyError:
+                    print("unknown", field, val)
                     unknown_fields = True
-        unknown_fields = mark_safe(unknown_fields)
         # is_bound is turned off so that the `initial` data is displayed.
         # Note that form is validated and cleaned with is_bound call.
         inputs_form.is_bound = False


### PR DESCRIPTION
The `Simulation.compute_eta` used `timezone.now()` as the key word for the default reference time when computing a simulation's ETA. However, in Python, function keywords hold state which means that `timezone.now()` is called once when the class is initialized and not each time the method is called.