### PR TITLE
Use `datalist` tag for discreet variables like booleans

### DIFF
--- a/webapp/apps/comp/meta_parameters.py
+++ b/webapp/apps/comp/meta_parameters.py
@@ -61,6 +61,13 @@ def translate_to_django(meta_parameters: dict) -> MetaParameters:
                 field = field(
                     label="", min_value=min_value, max_value=max_value, required=False
                 )
+            elif "choice" in data["validators"]:
+                field = forms.TypedChoiceField(
+                    label="",
+                    choices=[(c, c) for c in data["validators"]["choice"]["choices"]],
+                    required=False,
+                    coerce=int if data["type"] == "int" else float,
+                )
             else:
                 field = field(label="", required=False)
         else:  # bool

--- a/webapp/apps/comp/param.py
+++ b/webapp/apps/comp/param.py
@@ -2,6 +2,8 @@ from django import forms
 
 from .fields import (
     ValueField,
+    ChoiceValueField,
+    DataList,
     coerce_bool,
     coerce_float,
     coerce_int,
@@ -28,12 +30,12 @@ class Value:
         self.number_dims = number_dims
         if self.number_dims == 0 and "choice" in validators:
             choices_ = validators["choice"]["choices"]
-            if len(choices_) < 25:
-                choices_.remove(self.default_value)
-                choices_.insert(0, self.default_value)
-                choices = [(c, c) for c in choices_]
-            else:
-                choices = None
+            choices_.remove(self.default_value)
+            choices_.insert(0, self.default_value)
+            choices = [(c, c) for c in choices_]
+        elif self.number_dims == 0 and coerce_func.__name__ == "coerce_bool":
+            choices_ = [self.default_value, not self.default_value]
+            choices = [(c, c) for c in choices_]
         else:
             choices = None
         if isinstance(self.default_value, list):
@@ -44,10 +46,12 @@ class Value:
         attrs.update(field_kwargs)
         if self.number_dims == 0 and choices is not None:
             attrs["class"] += " unedited"
-            self.form_field = forms.TypedChoiceField(
+            self.form_field = ChoiceValueField(
                 label=self.label,
                 required=False,
-                widget=forms.Select(attrs=attrs),
+                widget=DataList(
+                    data_list=choices, placeholder=self.default_value, attrs=attrs
+                ),
                 coerce=coerce_func,
                 choices=choices,
                 **field_kwargs,

--- a/webapp/apps/comp/param.py
+++ b/webapp/apps/comp/param.py
@@ -54,6 +54,7 @@ class Value:
                 ),
                 coerce=coerce_func,
                 choices=choices,
+                number_dims=self.number_dims,
                 **field_kwargs,
             )
         else:

--- a/webapp/apps/comp/submit.py
+++ b/webapp/apps/comp/submit.py
@@ -131,7 +131,7 @@ class Submit:
                 self.ioutils.Parser.append_errors_warnings(
                     self.model.errors_warnings[inputs_style],
                     add_errors,
-                    {} if inputs_style == "GUI" else defaults[inputs_style],
+                    defaults.get(inputs_style, {}),
                 )
 
     def submit(self):

--- a/webapp/apps/comp/tests/test_fields.py
+++ b/webapp/apps/comp/tests/test_fields.py
@@ -4,10 +4,13 @@ from django import forms
 
 from webapp.apps.comp.fields import (
     ValueField,
+    ChoiceValueField,
+    DataList,
     coerce_bool,
     coerce_int,
     coerce_float,
     coerce_date,
+    coerce,
 )
 
 
@@ -76,3 +79,19 @@ def test_ValueField_zerodim():
     assert svf.clean("<,1,*") == ["<", 1, "*"]
     assert svf.clean("<") == ["<"]
     assert svf.clean("*") == ["*"]
+
+
+def test_ChoiceValueField():
+    cvf = ChoiceValueField(
+        [(True, True), (False, False)], coerce=coerce_bool, number_dims=0
+    )
+    assert cvf.clean("True") == True
+    assert cvf.clean("True,*,*,False") == [True, "*", "*", False]
+
+    cvf = ChoiceValueField(
+        [("hello", "hello"), ("world", "world")], coerce=coerce, number_dims=0
+    )
+    assert cvf.clean("hello") == "hello"
+    assert cvf.clean("<,hello,world") == ["<", "hello", "world"]
+    with pytest.raises(forms.ValidationError) as e:
+        cvf.clean("yep,bad input")

--- a/webapp/apps/comp/tests/test_params_w_labels.py
+++ b/webapp/apps/comp/tests/test_params_w_labels.py
@@ -9,7 +9,7 @@ from paramtools import Parameters, ValidationError
 
 from webapp.apps.comp.meta_parameters import translate_to_django, MetaParameters
 from webapp.apps.comp.displayer import Displayer
-from webapp.apps.comp.fields import ValueField
+from webapp.apps.comp.fields import ValueField, ChoiceValueField
 from webapp.apps.comp.tests.parser import LocalParser
 from webapp.apps.users.models import Project
 from webapp.apps.comp.ioutils import get_ioutils
@@ -74,7 +74,7 @@ def test_make_field_types(TestParams: Parameters, pt_metaparam: dict):
     spec = params.specification(meta_data=True, **mp_inst)
 
     param = Param("str_choice_param", spec["str_choice_param"])
-    assert isinstance(param.fields["str_choice_param"], forms.TypedChoiceField)
+    assert isinstance(param.fields["str_choice_param"], ChoiceValueField)
 
     param = Param("min_int_param", spec["min_int_param"])
     assert all([isinstance(field, ValueField) for _, field in param.fields.items()])


### PR DESCRIPTION
The [`datalist`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist) tag is a hybrid between the `select` and the text `input` tag. Users can type in custom values using the wild card operators, click the input box to view available options, or start typing to view a filtered list of suggested choices. For the boolean variables this looks like:

![Screenshot from 2019-05-31 09-34-38](https://user-images.githubusercontent.com/9206065/58709667-a7789800-8388-11e9-90de-b30006f45507.png)

and for regular discrete variables using the `choice` validator:

![Screenshot from 2019-05-31 09-45-45](https://user-images.githubusercontent.com/9206065/58709787-e6a6e900-8388-11e9-9cd8-5c8b47f7e05d.png)

Thanks for your input on this feature @andersonfrailey and @MattHJensen.