### PR TITLE
Model version not required on failed sim

### DIFF
--- a/webapp/apps/comp/serializers.py
+++ b/webapp/apps/comp/serializers.py
@@ -15,7 +15,7 @@ class OutputsSerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=(("SUCCESS", "Success"), ("FAIL", "Fail")))
     traceback = serializers.CharField(required=False)
     result = ResultSerializer(required=False)
-    model_version = serializers.CharField()
+    model_version = serializers.CharField(required=False)
     meta = serializers.JSONField()
 
 

--- a/webapp/apps/comp/tests/Matchups_v1_fail.json
+++ b/webapp/apps/comp/tests/Matchups_v1_fail.json
@@ -1,7 +1,6 @@
 {
     "job_id": "d8b340ef-b3e0-4e49-bb17-ffe0e6cb6711",
     "status": "FAIL",
-    "model_version": "v1.0.0",
     "traceback": "Traceback (most recent call last):\n  File \"/home/distributed/api/celery_app/__init__.py\", line 53, in f\n    outputs = func(*args, **kwargs)\n  File \"/home/distributed/api/celery_app/hdoupe_matchups_tasks.py\", line 60, in sim\n    return run(**kwargs)\n  File \"/home/distributed/api/celery_app/hdoupe_matchups_tasks.py\", line 55, in run\n    raise ValueError()\nValueError",
     "meta": {
         "task_times": [

--- a/webapp/apps/comp/tests/compute.py
+++ b/webapp/apps/comp/tests/compute.py
@@ -62,13 +62,7 @@ class MockCompute(Compute):
 
 class MockComputeWorkerFailure(MockCompute):
     next_response = None
-    outputs = json.dumps(
-        {
-            "status": "WORKER_FAILURE",
-            "model_version": "v1.0.0",
-            "traceback": "Error: whoops",
-        }
-    )
+    outputs = json.dumps({"status": "WORKER_FAILURE", "traceback": "Error: whoops"})
 
     def remote_query_job(self, url, params):
         self.client = None


### PR DESCRIPTION
This caused PUT requests on failed runs from the back end workers to be bounced and made the application hang even though the sim already failed.