### PR TITLE
Upgrade to s3like 1.4.0 to fix file name in zip file issue

### DIFF
--- a/distributed/requirements.txt
+++ b/distributed/requirements.txt
@@ -7,4 +7,4 @@ flask
 toolz
 gunicorn
 boto3
-s3like==1.3.1
+s3like==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ psycopg2-binary
 ipython
 markdown
 django-guardian
-s3like==1.3.0
+s3like==1.4.0


### PR DESCRIPTION
Resolves #153. The [s3like](https://github.com/comp-org/s3like) helper package now uses the output titles to create the file names of the objects within the zipfile which is available for download on the outputs page.