### PR TITLE
Response needs to be JSON encoded for worker failure

### DIFF
--- a/distributed/api/endpoints.py
+++ b/distributed/api/endpoints.py
@@ -83,7 +83,9 @@ def results():
         return json.dumps(async_result.result)
     elif async_result.failed():
         print("traceback", async_result.traceback)
-        return {"status": "WORKER_FAILURE", "traceback": async_result.traceback}
+        return json.dumps(
+            {"status": "WORKER_FAILURE", "traceback": async_result.traceback}
+        )
     else:
         resp = make_response("not ready", 202)
         return resp


### PR DESCRIPTION
Fixes bug where worker failure response throws a 500 error on the web app. See [this run](https://compmodels.org/PSLmodels/Tax-Brain/41188/) for an example.