### PR TITLE
Bump timeout for worker requests

### DIFF
--- a/webapp/apps/comp/compute.py
+++ b/webapp/apps/comp/compute.py
@@ -7,7 +7,7 @@ import requests_mock
 requests_mock.Mocker.TEST_PREFIX = "test"
 
 WORKER_HN = os.environ.get("WORKERS")
-TIMEOUT_IN_SECONDS = 1.5
+TIMEOUT_IN_SECONDS = 2.0
 MAX_ATTEMPTS_SUBMIT_JOB = 20
 
 


### PR DESCRIPTION
This PR bumps the time out for requests to the worker nodes to 2 seconds. Some of the user adjustments are very large, like 40 + params and 140+ parameter values. This takes about 1.02s on average for the Tax-Brain `validate_inputs` function to parse, which is a little close for the 1.5s timeout.