### PR TITLE
Bump timeout for requests to worker nodes to 2.5s

### DIFF
--- a/webapp/apps/comp/compute.py
+++ b/webapp/apps/comp/compute.py
@@ -7,7 +7,7 @@ import requests_mock
 requests_mock.Mocker.TEST_PREFIX = "test"
 
 WORKER_HN = os.environ.get("WORKERS")
-TIMEOUT_IN_SECONDS = 2.0
+TIMEOUT_IN_SECONDS = 2.5
 MAX_ATTEMPTS_SUBMIT_JOB = 20
 
 


### PR DESCRIPTION
Similar to #168. I found another simulation with validation turn around times closer to 1.4 seconds. This should give enough time to do the validation request.