### PR TITLE
COMP no longer 'title-izes' major sections

### DIFF
--- a/templates/comp/inputs_form.html
+++ b/templates/comp/inputs_form.html
@@ -174,7 +174,7 @@
             {% endif %}
             {% for section, params in default_form.items %}
               <div class="card card-body card-outer">
-                {% include 'comp/inputs/major_section.html' with title=section.title params=params %}
+                {% include 'comp/inputs/major_section.html' with title=section params=params %}
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
Cost-of-Capital-Calculator has a major section "ccc" which looks like "Ccc" after the Python `title` method is called on it. For this reason, COMP no longer calls the title method on section titles. It's up to the projects to define exactly how the section headers should look.

Before:
![Screenshot from 2019-07-02 22-34-35](https://user-images.githubusercontent.com/9206065/60559161-a2a55c00-9d19-11e9-86cc-19003edd7493.png)

After:
![Screenshot from 2019-07-02 22-34-49](https://user-images.githubusercontent.com/9206065/60559162-a2a55c00-9d19-11e9-834d-6796d00363b4.png)

Maintainers of affected projects: @andersonfrailey @Peter-Metz @jdebacker