### PR TITLE
Swap default tab and order

### DIFF
--- a/templates/profile/profile_base.html
+++ b/templates/profile/profile_base.html
@@ -7,24 +7,24 @@
       {% csrf_token %}
       <ul class="nav nav-tabs" id="myTab" role="tablist">
         <li class="nav-item">
-          <a class="nav-link active" id="models-tab" data-toggle="tab" href="#models" role="tab" aria-controls="models" aria-selected="false">My Models</a>
+          <a class="nav-link active" id="simulations-tab" data-toggle="tab" href="#simulations" role="tab" aria-controls="models" aria-selected="false">My Simulations</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link" id="simulations-tab" data-toggle="tab" href="#simulations" role="tab" aria-controls="simulations" aria-selected="true">My Simulations</a>
+            <a class="nav-link" id="models-tab" data-toggle="tab" href="#models" role="tab" aria-controls="simulations" aria-selected="true">My Models</a>
           </li>
         <li class="nav-item">
           <a class="nav-link" id="costs-tab" data-toggle="tab" href="#costs" role="tab" aria-controls="costs" aria-selected="false">Costs</a>
         </li>
       </ul>
       <div class="tab-content" id="profileTab">
-        <div class="tab-pane fade show active" id="models" role="tabpanel" aria-labelledby="models-tab">
+        <div class="tab-pane fade show active" id="simulations" role="tabpanel" aria-labelledby="simulations-tab">
           <div class="profile-tab-content">
-              {% include 'profile/models.html' %}
+              {% include 'profile/simulations.html' %}
           </div>
         </div>
-        <div class="tab-pane fade" id="simulations" role="tabpanel" aria-labelledby="simulations-tab">
+        <div class="tab-pane fade" id="models" role="tabpanel" aria-labelledby="models-tab">
           <div class="profile-tab-content">
-            {% include 'profile/simulations.html' %}
+            {% include 'profile/models.html' %}
           </div>
         </div>
         <div class="tab-pane fade" id="costs" role="tabpanel" aria-labelledby="costs-tab">

--- a/webapp/apps/users/models.py
+++ b/webapp/apps/users/models.py
@@ -57,8 +57,8 @@ class Profile(models.Model):
         runs = {}
         for project in projects:
             queryset = self.sims.filter(project=project)
-            # if queryset.count() > 0:
-            runs[project.title] = queryset.all().order_by("-pk")
+            if queryset.count() > 0:
+                runs[project.title] = queryset.all().order_by("-pk")
         return runs
 
     class Meta:

--- a/webapp/apps/users/tests/test_models.py
+++ b/webapp/apps/users/tests/test_models.py
@@ -45,7 +45,11 @@ class TestUserModels:
         sims = profile.sims_breakdown()
 
         # check that all apps are queried.
-        titles = {project.title for project in Project.objects.all()}
+        titles = {
+            project.title
+            for project in Project.objects.all()
+            if profile.sims.filter(project=project).count()
+        }
         assert titles == set(sims.keys())
 
         testapprun = test_models[0]


### PR DESCRIPTION
Resolves #171. This PR makes it so that the sims tab only shows models for which a user has simulations, i.e. models that the user has not used will not be shown:

![Screenshot from 2019-07-03 10-08-13](https://user-images.githubusercontent.com/9206065/60598316-7f5ec900-9d7a-11e9-85a0-5a546ecaf4e4.png)
