### PR TITLE
UI fixes for the simulations tab in the user profile page

### DIFF
--- a/templates/comp/inputs/param.html
+++ b/templates/comp/inputs/param.html
@@ -7,8 +7,9 @@
     <div class="col-xs-12">
       <label>
         {{ param.title }}
-        {% include 'comp/inputs/fields/tooltip.html' with text=param.info %}
-
+        {% if param.info %}
+          {% include 'comp/inputs/fields/tooltip.html' with text=param.info %}
+        {% endif %}
       <!-- TODO: add auxillary block for optional checkbox parameter. -->
       {% if param.has_checkbox %}
         {% with form|dict_get:param.checkbox_field.name as checkbox_field %}

--- a/templates/profile/simulations.html
+++ b/templates/profile/simulations.html
@@ -1,5 +1,5 @@
 {% for project, queryset in runs.items %}
-  <h4>{{project}}</h4>
+  <h5><a href="/{{project}}/">{{project}}</a></h5>
   <table class="table">
     <tr>
       <th>Output</th>

--- a/templates/profile/simulations.html
+++ b/templates/profile/simulations.html
@@ -1,36 +1,55 @@
+{% load strings %}
+
 {% for project, queryset in runs.items %}
-  <h5><a href="/{{project}}/">{{project}}</a></h5>
-  <table class="table">
-    <tr>
-      <th>Output</th>
-      <th>Run time (s)</th>
-      <th>Run cost ($)</th>
-      <th>Date (EST)</th>
-      <th>Status</th>
-    </tr>
-    {% for run in queryset %}
+<div class="card card-body card-outer mb-4">
+    <h5><a href="/{{project}}/">{{project}}</a>
+    <div class="float-right">
+      <button
+        class="btn collapse-button"
+        type="button"
+        data-toggle="collapse"
+        data-target="#{{project|make_id}}-collapse-major"
+        aria-expanded="false"
+        aria-controls="{{project|make_id}}-collapse-major"
+        style="margin-left:20px;">
+        <i class="far fa-plus-square" style="size:5x;" ></i>
+      </button>
+    </div>
+  </h5>
+  <div class="collapse collapse-plus-minus" id="{{project|make_id}}-collapse-major">
+    <table class="container table table-responsive-md">
       <tr>
-        <td>
-          <div class="row">
-            <div class="col align-self-start">
-              <a href="{{run.get_absolute_url}}">{{run.model_pk}}</a>
-            </div>
-            <div class="col align-self-center ">
-              <label
-                data-toggle="tooltip"
-                data-placement="top"
-                title="Edit parameters">
-                <a class="color-inherit hover-blue" href="{{run.get_absolute_edit_url}}"><i class="fas fa-edit fa-sm"></i></a></td>
-              </label>
-            </div>
-          </div>
-        <td>{{run.run_time}}</td>
-        <td>{{run.effective_cost}}</td>
-        <td>{{run.creation_date}}</td>
-        <td class="sim-status">{{run.status}}</td>
+        <th>Output</th>
+        <th>Run time (s)</th>
+        <th>Run cost ($)</th>
+        <th>Date (EST)</th>
+        <th>Status</th>
       </tr>
-    {% endfor %}
-  </table>
+      {% for run in queryset %}
+        <tr>
+          <td>
+            <div class="row">
+              <div class="col align-self-start">
+                <a href="{{run.get_absolute_url}}">{{run.model_pk}}</a>
+              </div>
+              <div class="col align-self-center ">
+                <label
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="Edit parameters">
+                  <a class="color-inherit hover-blue" href="{{run.get_absolute_edit_url}}"><i class="fas fa-edit fa-sm"></i></a></td>
+                </label>
+              </div>
+            </div>
+          <td>{{run.run_time}}</td>
+          <td>{{run.effective_cost}}</td>
+          <td>{{run.creation_date}}</td>
+          <td class="sim-status">{{run.status}}</td>
+        </tr>
+      {% endfor %}
+    </table>
+  </div>
+</div>
 {% endfor %}
 
 <script>

--- a/webapp/apps/comp/templatetags/strings.py
+++ b/webapp/apps/comp/templatetags/strings.py
@@ -5,7 +5,7 @@ register = template.Library()
 
 @register.filter
 def make_id(name):
-    return "-".join(name.split())
+    return "-".join(name.lower().replace("/", "-").split())
 
 
 @register.filter

--- a/webapp/apps/users/models.py
+++ b/webapp/apps/users/models.py
@@ -58,7 +58,9 @@ class Profile(models.Model):
         for project in projects:
             queryset = self.sims.filter(project=project)
             if queryset.count() > 0:
-                runs[project.title] = queryset.all().order_by("-pk")
+                runs[
+                    f"{project.owner.user.username}/{project.title}"
+                ] = queryset.all().order_by("-pk")
         return runs
 
     class Meta:

--- a/webapp/apps/users/tests/test_models.py
+++ b/webapp/apps/users/tests/test_models.py
@@ -46,20 +46,20 @@ class TestUserModels:
 
         # check that all apps are queried.
         titles = {
-            project.title
+            f"{project.owner.user.username}/{project.title}"
             for project in Project.objects.all()
             if profile.sims.filter(project=project).count()
         }
         assert titles == set(sims.keys())
 
         testapprun = test_models[0]
-        assert sims["Used-for-testing"].count() == 1
-        for sim in sims["Used-for-testing"].all():
+        assert sims["modeler/Used-for-testing"].count() == 1
+        for sim in sims["modeler/Used-for-testing"].all():
             assert sim == testapprun
 
         sponsoredtestapprun = test_models[1]
-        assert sims["Used-for-testing-sponsored-apps"].count() == 1
-        for sim in sims["Used-for-testing-sponsored-apps"].all():
+        assert sims["modeler/Used-for-testing-sponsored-apps"].count() == 1
+        for sim in sims["modeler/Used-for-testing-sponsored-apps"].all():
             assert sim == sponsoredtestapprun
 
     def test_project_show_sponsor(self, test_models):


### PR DESCRIPTION
- Uses owner/title notation for models in case there are multiple users that have a model with the same name.
- Puts the simulations tables for each model in a bootstrap card to make the page less cluttered.
- Makes the tables within those cards responsive so that they do not run off the outer card when viewing from a mobile device.
- Also drops the info icon for parameters that do not have any info specified.