### PR TITLE
Bump time out to 6 secs

### DIFF
--- a/webapp/apps/comp/compute.py
+++ b/webapp/apps/comp/compute.py
@@ -7,8 +7,8 @@ import requests_mock
 requests_mock.Mocker.TEST_PREFIX = "test"
 
 WORKER_HN = os.environ.get("WORKERS")
-TIMEOUT_IN_SECONDS = 4
-MAX_ATTEMPTS_SUBMIT_JOB = 6
+TIMEOUT_IN_SECONDS = 6
+MAX_ATTEMPTS_SUBMIT_JOB = 4
 
 
 class JobFailError(Exception):


### PR DESCRIPTION
This bumps the request timeout from 4 to 6 seconds while I'm working on a long-term solution to this issue.