### PR TITLE
Workers can only reserve 1 task at a time

### DIFF
--- a/distributed/api/celery_app/__init__.py
+++ b/distributed/api/celery_app/__init__.py
@@ -55,7 +55,11 @@ celery_app = Celery(
     "celery_app", broker=CELERY_BROKER_URL, backend=CELERY_RESULT_BACKEND
 )
 celery_app.conf.update(
-    task_serializer="json", accept_content=["msgpack", "json"], task_routes=task_routes
+    task_serializer="json",
+    accept_content=["msgpack", "json"],
+    task_routes=task_routes,
+    worker_prefetch_multiplier=1,
+    task_acks_late=True,
 )
 
 


### PR DESCRIPTION
Set [`worker_prefetch_multiplier` to 1](https://docs.celeryproject.org/en/latest/userguide/configuration.html#worker-prefetch-multiplier) so that workers can only reserve a single task at a time. Perhaps, **this** will finally solve the problem of new workers (added via autoscaling) not consuming jobs because they've already been reserved by existing workers.